### PR TITLE
feat: add docker, ci and ops tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Example environment variables for CESIZEN
+
+# Database configuration
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=cesizen
+DB_USER=cesizen
+DB_PASS=change-me
+
+# Security
+JWT_SECRET=change-me
+CORS_ORIGINS=http://localhost
+
+# Service URLs
+API_BASE_URL=http://localhost:5000
+FRONT_BASE_URL=http://localhost
+API_URL=http://localhost/api
+
+# Application modes
+NODE_ENV=development
+FLASK_ENV=development
+
+# Gunicorn
+GUNICORN_WORKERS=4
+GUNICORN_THREADS=2
+LOG_LEVEL=info
+
+# SMTP configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=username
+SMTP_PASS=password
+
+# NGINX
+NGINX_SERVER_NAME=localhost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS Instructions
+
+## Development
+- Use `npm install --legacy-peer-deps` when installing frontend dependencies.
+- Run `npm test` in `Front/` and `pytest` in `Back/` after changes.
+- Do not commit secrets or `.env` files.
+- Update `Back/requirements.txt` when Python dependencies change.
+
+## Docker
+- Docker may require privileged access; the daemon could fail to start in restricted environments.
+- Backend and database use the private network; reverse proxy is the only service exposing ports.
+

--- a/Back/requirements.txt
+++ b/Back/requirements.txt
@@ -1,0 +1,6 @@
+flask
+gunicorn
+mysql-connector-python
+bcrypt
+python-dotenv
+requests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,74 @@
+pipeline {
+  agent { docker { image 'docker:27.5.1' args '--privileged -v /var/run/docker.sock:/var/run/docker.sock' } }
+  environment {
+    DOCKERHUB = credentials('dockerhub')
+    SONAR_TOKEN = credentials('sonar-token')
+    SONAR_HOST_URL = 'https://sonar.example.com'
+  }
+  stages {
+    stage('Checkout') {
+      steps { checkout scm }
+    }
+    stage('Lint') {
+      steps {
+        dir('Front') { sh 'npm ci --legacy-peer-deps && npm run lint' }
+        dir('Back') { sh 'flake8 .' }
+      }
+    }
+    stage('Build') {
+      steps {
+        dir('Front') { sh 'npm run build --configuration production' }
+      }
+    }
+    stage('Test') {
+      steps {
+        dir('Front') { sh 'npm test -- --watch=false' }
+        dir('Back') { sh 'pytest --cov=.' }
+      }
+      post {
+        always {
+          junit 'Front/test-results/**/*.xml'
+          junit 'Back/test-results/**/*.xml'
+          archiveArtifacts artifacts: 'coverage/**', allowEmptyArchive: true
+        }
+      }
+    }
+    stage('Analyse') {
+      steps {
+        sh 'sonar-scanner'
+      }
+    }
+    stage('Build_Images') {
+      steps {
+        script {
+          def sha = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
+          sh "docker build -f frontend/Dockerfile -t ${DOCKERHUB_USR}/frontend:${sha} -t ${DOCKERHUB_USR}/frontend:latest ."
+          sh "docker build -f backend/Dockerfile -t ${DOCKERHUB_USR}/backend:${sha} -t ${DOCKERHUB_USR}/backend:latest ."
+          sh "docker build -f nginx/Dockerfile -t ${DOCKERHUB_USR}/nginx:${sha} -t ${DOCKERHUB_USR}/nginx:latest ."
+        }
+      }
+    }
+    stage('Push_Images') {
+      steps {
+        withDockerRegistry([credentialsId: 'dockerhub']) {
+          sh 'docker push ${DOCKERHUB_USR}/frontend --all-tags'
+          sh 'docker push ${DOCKERHUB_USR}/backend --all-tags'
+          sh 'docker push ${DOCKERHUB_USR}/nginx --all-tags'
+        }
+      }
+    }
+    stage('Deploy') {
+      when { branch 'main' }
+      steps {
+        sshagent(credentials: ['deploy_ssh']) {
+          sh 'ssh $DEPLOY_USER@$DEPLOY_HOST "cd /path/to/app && git pull && docker compose -f docker-compose.prod.yml pull && docker compose -f docker-compose.prod.yml up -d --remove-orphans"'
+        }
+      }
+    }
+  }
+  post {
+    always {
+      archiveArtifacts artifacts: '**/test-results/**/*.xml', allowEmptyArchive: true
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# CESIZEN
+
+Application web de bien-être composée d'un frontend Angular et d'un backend Flask.
+
+## Docker
+Voir `README_DOCKER.md` pour l'exécution avec Docker.
+
+## CI/CD
+Pipeline Jenkins décrit dans `Jenkinsfile`.
+
+## Runbooks
+Consulter le dossier `ops/` pour les procédures d'exploitation.

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -1,0 +1,29 @@
+# Docker Setup for CESIZEN
+
+## Prerequisites
+- Docker and Docker Compose
+- `.env` file based on `.env.example`
+
+## Development
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
+
+## Production
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+
+## Stop
+```bash
+docker compose down
+```
+
+## Reset Database
+```bash
+rm -rf data/db
+```
+
+## Debugging
+- Use `docker compose logs -f <service>`
+- Tokens are never stored in plain text; only hashes are persisted.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-alpine
+WORKDIR /app
+ENV PYTHONUNBUFFERED=1
+COPY Back/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY Back/ ./
+COPY backend/gunicorn.conf.py ./
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:5000/healthz || exit 1

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -1,0 +1,7 @@
+import os
+
+workers = int(os.getenv("GUNICORN_WORKERS", "4"))
+threads = int(os.getenv("GUNICORN_THREADS", "2"))
+timeout = 60
+bind = "0.0.0.0:5000"
+loglevel = os.getenv("LOG_LEVEL", "info")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,63 @@
+version: "3.9"
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    networks:
+      - public
+    healthcheck:
+      test: ["CMD-SHELL","curl -fsS http://localhost/healthz || exit 1"]
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file: .env
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - private
+    healthcheck:
+      test: ["CMD-SHELL","curl -fsS http://localhost:5000/healthz || exit 1"]
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: "${DB_PASS}"
+      MYSQL_DATABASE: "${DB_NAME}"
+      MYSQL_USER: "${DB_USER}"
+      MYSQL_PASSWORD: "${DB_PASS}"
+    volumes:
+      - db_data:/var/lib/mysql
+    networks:
+      - private
+    healthcheck:
+      test: ["CMD-SHELL","mysqladmin ping -h localhost -p${DB_PASS} || exit 1"]
+  nginx:
+    build:
+      context: .
+      dockerfile: nginx/Dockerfile
+    depends_on:
+      frontend:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - public
+      - private
+    env_file: .env
+    volumes:
+      - ./certbot:/var/www/certbot
+      - ./letsencrypt:/etc/letsencrypt
+    healthcheck:
+      test: ["CMD-SHELL","curl -fsS http://localhost/healthz || exit 1"]
+
+networks:
+  public:
+  private:
+
+volumes:
+  db_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,73 @@
+version: "3.9"
+services:
+  frontend:
+    image: ${DOCKER_REPO}/frontend:${IMAGE_TAG:-latest}
+    networks:
+      - public
+    healthcheck:
+      test: ["CMD-SHELL","curl -fsS http://localhost/healthz || exit 1"]
+  backend:
+    image: ${DOCKER_REPO}/backend:${IMAGE_TAG:-latest}
+    env_file: .env
+    secrets:
+      - db_user
+      - db_pass
+      - jwt_secret
+    environment:
+      DB_USER_FILE: /run/secrets/db_user
+      DB_PASS_FILE: /run/secrets/db_pass
+      JWT_SECRET_FILE: /run/secrets/jwt_secret
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - private
+    healthcheck:
+      test: ["CMD-SHELL","curl -fsS http://localhost:5000/healthz || exit 1"]
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: "${DB_PASS}"
+      MYSQL_DATABASE: "${DB_NAME}"
+      MYSQL_USER: "${DB_USER}"
+      MYSQL_PASSWORD: "${DB_PASS}"
+    volumes:
+      - db_data:/var/lib/mysql
+    networks:
+      - private
+    healthcheck:
+      test: ["CMD-SHELL","mysqladmin ping -h localhost -p${DB_PASS} || exit 1"]
+  nginx:
+    image: ${DOCKER_REPO}/nginx:${IMAGE_TAG:-latest}
+    depends_on:
+      frontend:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - public
+      - private
+    env_file: .env
+    volumes:
+      - ./certbot:/var/www/certbot
+      - ./letsencrypt:/etc/letsencrypt
+    healthcheck:
+      test: ["CMD-SHELL","curl -fsS http://localhost/healthz || exit 1"]
+
+secrets:
+  db_user:
+    file: ./secrets/db_user.txt
+  db_pass:
+    file: ./secrets/db_pass.txt
+  jwt_secret:
+    file: ./secrets/jwt_secret.txt
+
+networks:
+  public:
+  private:
+
+volumes:
+  db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+# Frontend build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY Front/package*.json ./
+RUN npm ci --legacy-peer-deps
+COPY Front/ ./
+RUN npm run build --configuration production
+
+# Nginx stage serving static files
+FROM nginx:alpine
+COPY --from=build /app/dist/ /usr/share/nginx/html
+# simple healthcheck endpoint
+RUN echo 'ok' > /usr/share/nginx/html/healthz
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost/healthz || exit 1

--- a/jenkins/README_JENKINS.md
+++ b/jenkins/README_JENKINS.md
@@ -1,0 +1,11 @@
+# Jenkins Setup
+
+1. Create a Multibranch Pipeline job pointing to the repository.
+2. Configure GitHub webhook for push and pull request events.
+3. Required credentials:
+   - `dockerhub` (username/password)
+   - `sonar-token` (Secret text)
+   - `deploy_ssh` (SSH private key)
+4. Global environment variables:
+   - `SONAR_HOST_URL`
+5. Agents must provide Docker and Docker Compose.

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+RUN mkdir -p /etc/letsencrypt /var/www/certbot
+EXPOSE 80 443
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost/healthz || exit 1

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,57 @@
+env CORS_ORIGINS;
+worker_processes auto;
+
+events { worker_connections 1024; }
+
+http {
+    map $http_origin $cors_origin {
+        default "";
+        ~^($CORS_ORIGINS)$ $http_origin;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name ${NGINX_SERVER_NAME};
+        # ssl_certificate     /etc/letsencrypt/live/${NGINX_SERVER_NAME}/fullchain.pem;
+        # ssl_certificate_key /etc/letsencrypt/live/${NGINX_SERVER_NAME}/privkey.pem;
+        # To generate certificates with certbot, mount /etc/letsencrypt and /var/www/certbot
+
+        add_header Strict-Transport-Security "max-age=15552000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self' https:" always;
+
+        add_header Access-Control-Allow-Origin $cors_origin always;
+        add_header Access-Control-Allow-Methods "GET,POST,PUT,DELETE,OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization,Content-Type" always;
+
+        client_max_body_size 5m;
+
+        location / {
+            proxy_pass http://frontend/;
+            try_files $uri $uri/ /index.html;
+            location /assets/ {
+                expires 30d;
+            }
+        }
+
+        location /api/ {
+            proxy_pass http://backend:5000/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /healthz {
+            return 200 'ok';
+        }
+    }
+}

--- a/ops/RUNBOOK_BACKUP_RESTORE.md
+++ b/ops/RUNBOOK_BACKUP_RESTORE.md
@@ -1,0 +1,11 @@
+# Backup and Restore Runbook
+
+## Backup
+1. Run `scripts/backup_db.sh`.
+2. Store the generated `.sql.gpg` file securely.
+3. Rotate old backups according to policy.
+
+## Restore
+1. Locate desired backup file.
+2. Run `scripts/restore_db.sh <backup-file>`.
+3. Confirm data integrity.

--- a/ops/RUNBOOK_DEPLOY.md
+++ b/ops/RUNBOOK_DEPLOY.md
@@ -1,0 +1,5 @@
+# Deployment Runbook
+1. SSH to server.
+2. Pull images: `docker compose -f docker-compose.prod.yml pull`.
+3. Apply compose: `docker compose -f docker-compose.prod.yml up -d --remove-orphans`.
+4. Verify with `curl -f https://<domain>/healthz`.

--- a/ops/RUNBOOK_ROLLBACK.md
+++ b/ops/RUNBOOK_ROLLBACK.md
@@ -1,0 +1,8 @@
+# Rollback Runbook
+1. SSH to server.
+2. Identify previous tag.
+3. `docker compose -f docker-compose.prod.yml down`.
+4. `docker pull ${DOCKER_REPO}/frontend:<previous>` and same for backend and nginx.
+5. Update compose file environment if needed.
+6. `docker compose -f docker-compose.prod.yml up -d` with previous tag.
+7. Verify healthchecks.

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+[ -f .env ] && . .env
+TS=$(date +%F_%H-%M-%S)
+FILE="backup_${TS}.sql"
+mysqldump -h "$DB_HOST" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" > "$FILE"
+gpg --symmetric --cipher-algo AES256 "$FILE"
+rm "$FILE"
+echo "Backup stored in ${FILE}.gpg"

--- a/scripts/restore_db.sh
+++ b/scripts/restore_db.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+FILE="$1"
+[ -f .env ] && . .env
+TMP=$(mktemp)
+gpg --decrypt "$FILE" > "$TMP"
+mysql -h "$DB_HOST" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" < "$TMP"
+rm "$TMP"
+echo "Restored from $FILE"

--- a/scripts/wait-for.sh
+++ b/scripts/wait-for.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+HOST="$1"
+PORT="$2"
+shift 2
+until nc -z "$HOST" "$PORT"; do
+  echo "Waiting for $HOST:$PORT..."
+  sleep 1
+done
+exec "$@"

--- a/secrets/README_SECRETS.md
+++ b/secrets/README_SECRETS.md
@@ -1,0 +1,33 @@
+# Secrets Management
+
+## Production Secrets
+- Use Docker secrets for sensitive values.
+- Expect files at `/run/secrets/db_user`, `/run/secrets/db_pass`, and `/run/secrets/jwt_secret`.
+
+## Jenkins Deployment
+- Jenkins must export required variables such as database credentials and `JWT_SECRET`.
+- Use Jenkins credentials store for `dockerhub`, `sonar-token`, and SSH keys.
+
+## Key Rotation
+- Rotate secrets regularly and remove old values from the server.
+- Store backups securely and respect retention policies.
+
+## Compose Example
+```yaml
+services:
+  backend:
+    secrets:
+      - db_user
+      - db_pass
+      - jwt_secret
+secrets:
+  db_user:
+    file: ./secrets/db_user.txt
+  db_pass:
+    file: ./secrets/db_pass.txt
+  jwt_secret:
+    file: ./secrets/jwt_secret.txt
+```
+
+## Notes
+- Never commit `.env` files or secret material.


### PR DESCRIPTION
## Summary
- containerize Angular frontend, Flask backend and reverse proxy
- add Jenkins pipeline, runbooks and secrets guidance
- provide utility scripts for waiting and database backups

## Testing
- `npm run build -- --configuration production`
- `npm test -- --watch=false` *(failed: Cannot find module 'webpack' - resolved by installing dependency)*
- `pytest` *(failed: HTTPConnectionPool(host='localhost', port=5000) Max retries exceeded)*
- `flake8 Back` *(failed: multiple style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a77baed2a4832f80f4492b9a9327e6